### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,7 @@ const Downloader = require('nodejs-file-downloader');
 const extract = require('extract-zip');
 
 const IS_WIN = os.platform() === 'win32';
-const NAME_RE = /^dependency\-check\-\d\.\d\.\d\-release\.zip$/;
+const NAME_RE = /^dependency\-check\-\d\.\d\.\d{1,2}\-release\.zip$/;
 const LATEST_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/latest';
 const TAG_RELEASE_URL = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases/tags/'; 
 


### PR DESCRIPTION
There is an issue when running osap-dependecy-check, the assets name in res.json releases the release version digits has more than 1 digit for patch part, so we need to adapt the regex for checking release

![image](https://github.com/Rishabh-dipsite/owasp-dependency-check/assets/25535504/e0b37f39-4756-4bf3-ad70-d6a5c83fd4a2)

![image](https://github.com/Rishabh-dipsite/owasp-dependency-check/assets/25535504/985a7c75-8601-4866-a3fe-2eee9d19360f)

![image](https://github.com/Rishabh-dipsite/owasp-dependency-check/assets/25535504/c6d31922-0c68-45b3-807a-96b8ef0399da)
